### PR TITLE
Fix HomeController logger warning

### DIFF
--- a/TKBYSApp.Web/Controllers/HomeController.cs
+++ b/TKBYSApp.Web/Controllers/HomeController.cs
@@ -12,6 +12,7 @@ public class HomeController(ILogger<HomeController> logger) : Controller
 
     public IActionResult Index()
     {
+        _logger.LogInformation("Anasayfa görüntülendi: {Timestamp}", DateTimeOffset.UtcNow);
         return View();
     }
 


### PR DESCRIPTION
## Summary
- log when the home page is displayed so the injected logger is used

## Testing
- dotnet build *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0411de5e883219b43266c9c6b98e8